### PR TITLE
feat: build multi-platform image (amd64, arm64)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,46 +3,31 @@ kind: pipeline
 type: kubernetes
 name: default
 
-services:
-  - name: docker
-    image: docker:19.03-dind
-    entrypoint:
-      - dockerd
-    command:
-      - --dns=8.8.8.8
-      - --dns=8.8.4.4
-      - --log-level=error
-    privileged: true
-    volumes:
-      - name: docker-socket
-        path: /var/run
-
 steps:
   - name: setup-ci
     image: autonomy/build-container:latest
     commands:
-      - sleep 5 # Give docker enough time to start.
-      - apk add coreutils
-      - docker buildx create --driver docker-container --platform linux/amd64 --buildkitd-flags "--allow-insecure-entitlement security.insecure" --name local --use unix:///var/outer-run/docker.sock
-      - docker buildx inspect --bootstrap
       - git fetch --tags
+      - install-ci-key
+      - setup-buildx-amd64-arm64
     environment:
-      BUILDX_KUBECONFIG:
-        from_secret: kubeconfig
+      SSH_KEY:
+        from_secret: ssh_key
+      DOCKER_CLI_EXPERIMENTAL: enabled
     privileged: true
     volumes:
       - name: docker-socket
         path: /var/run
-      - name: outerdockersock
-        path: /var/outer-run
+      - name: ssh
+        path: /root/.ssh
       - name: docker
         path: /root/.docker/buildx
-      - name: kube
-        path: /root/.kube
 
   - name: build-container
     image: autonomy/build-container:latest
     pull: always
+    environment:
+      DOCKER_CLI_EXPERIMENTAL: enabled
     commands:
       - make
     when:
@@ -52,12 +37,10 @@ steps:
     volumes:
       - name: docker-socket
         path: /var/run
-      - name: outerdockersock
-        path: /var/outer-run
+      - name: ssh
+        path: /root/.ssh
       - name: docker
         path: /root/.docker/buildx
-      - name: kube
-        path: /root/.kube
 
   - name: build-and-publish-container
     image: autonomy/build-container:latest
@@ -77,22 +60,18 @@ steps:
     volumes:
       - name: docker-socket
         path: /var/run
-      - name: outerdockersock
-        path: /var/outer-run
+      - name: ssh
+        path: /root/.ssh
       - name: docker
         path: /root/.docker/buildx
-      - name: kube
-        path: /root/.kube
 
 volumes:
   - name: docker-socket
-    temp: {}
-  - name: outerdockersock
     host:
       path: /var/ci-docker
   - name: docker
     temp: {}
-  - name: kube
+  - name: ssh
     temp: {}
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,30 @@
-## Using the builder this way keeps us from having to install wget and adding an extra 
+## Using the builder this way keeps us from having to install wget and adding an extra
 ## fat step that just does a chmod on the kubelet binary
-FROM alpine:latest as builder
 
+FROM alpine:latest as builder-amd64
+
+ARG TARGETARCH
 ARG KUBELET_VER
-ARG KUBELET_SHA512
-ARG KUBELET_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBELET_VER}/bin/linux/amd64/kubelet
+ARG KUBELET_SHA512_AMD64
+ARG KUBELET_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBELET_VER}/bin/linux/${TARGETARCH}/kubelet
 
 RUN wget -q -O /kubelet ${KUBELET_URL} && \
-    echo "${KUBELET_SHA512}  /kubelet" | sha512sum -c && \
+    echo "${KUBELET_SHA512_AMD64}  /kubelet" | sha512sum -c && \
     chmod +x /kubelet
+
+FROM alpine:latest as builder-arm64
+
+ARG TARGETARCH
+ARG KUBELET_VER
+ARG KUBELET_SHA512_ARM64
+ARG KUBELET_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBELET_VER}/bin/linux/${TARGETARCH}/kubelet
+
+RUN wget -q -O /kubelet ${KUBELET_URL} && \
+    echo "${KUBELET_SHA512_ARM64}  /kubelet" | sha512sum -c && \
+    chmod +x /kubelet
+
+ARG TARGETARCH
+FROM builder-${TARGETARCH} as builder
 
 FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-iptables:v12.1.2 as container
 

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,11 @@ BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 NAME := kubelet
 KUBELET_VER := v1.19.0
-KUBELET_SHA512 := dd5cc49c2f867a73658e3196f147df2336d50118ff2a09690a58ea9f5f8ed57e6bee2e43407dc10afc362a8da7932fee08f380d0c787137750fe2293064cc601
+KUBELET_SHA512_AMD64 := dd5cc49c2f867a73658e3196f147df2336d50118ff2a09690a58ea9f5f8ed57e6bee2e43407dc10afc362a8da7932fee08f380d0c787137750fe2293064cc601
+KUBELET_SHA512_ARM64 := 0dffdbcc86dc574cb1887f1ecaf6ebb996179106f3bb41354f10d66ed744adb2cca550fc89eef0117d133704c7c8b7a513d925bea50f5c7dd57a668b9bb7a942
 
 BUILD := docker buildx build
-PLATFORM ?= linux/amd64
+PLATFORM ?= linux/amd64,linux/arm64
 PROGRESS ?= auto
 PUSH ?= false
 COMMON_ARGS := --file=Dockerfile
@@ -19,7 +20,8 @@ COMMON_ARGS += --build-arg=REGISTRY_AND_USERNAME=$(REGISTRY_AND_USERNAME)
 COMMON_ARGS += --build-arg=NAME=$(NAME)
 COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=KUBELET_VER=$(KUBELET_VER)
-COMMON_ARGS += --build-arg=KUBELET_SHA512=$(KUBELET_SHA512)
+COMMON_ARGS += --build-arg=KUBELET_SHA512_AMD64=$(KUBELET_SHA512_AMD64)
+COMMON_ARGS += --build-arg=KUBELET_SHA512_ARM64=$(KUBELET_SHA512_ARM64)
 
 all: container
 
@@ -32,7 +34,7 @@ target-%: ## Builds the specified target defined in the Dockerfile. The build re
 local-%: ## Builds the specified target defined in the Dockerfile using the local output type. The build result will be output to the specified local destination.
 	@$(MAKE) target-$* TARGET_ARGS="--output=type=local,dest=$(DEST) $(TARGET_ARGS)"
 
-docker-%: ## Builds the specified target defined in the Dockerfile using the docker output type. The build result will be loaded into docker.
+docker-%: ## Builds the specified target defined in the Dockerfile using the default output type.
 	@$(MAKE) target-$* TARGET_ARGS="--tag $(REGISTRY_AND_USERNAME)/$(NAME):$(TAG) $(TARGET_ARGS)"
 
 .PHONY: container


### PR DESCRIPTION
AFAIK there's no way to to do doube variable expansion in Dockerfile,
like `${KUBELET_SHA_${TARGETARCH}}`, so we have to do a bit of an ugly
trick here.

Fixes #5

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>